### PR TITLE
fix: 修复 sqlalchemy 的报错

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复 sqlalchemy 的报错
+
 ## [0.1.1] - 2023-11-21
 
 ### Fixed

--- a/nonebot_plugin_user/utils.py
+++ b/nonebot_plugin_user/utils.py
@@ -58,19 +58,20 @@ async def get_user(platform: str, platform_id: str) -> User:
                 await session.commit()
                 return user
         except exc.IntegrityError:
-            user = (
-                await session.scalars(
-                    select(User)
-                    .where(Bind.platform == platform)
-                    .where(Bind.platform_id == platform_id)
-                    .join(Bind, User.id == Bind.bind_id)
-                )
-            ).one_or_none()
+            async with get_session() as session:
+                user = (
+                    await session.scalars(
+                        select(User)
+                        .where(Bind.platform == platform)
+                        .where(Bind.platform_id == platform_id)
+                        .join(Bind, User.id == Bind.bind_id)
+                    )
+                ).one_or_none()
 
-            if not user:
-                raise ValueError("创建用户失败")  # pragma: no cover
+                if not user:
+                    raise ValueError("创建用户失败")  # pragma: no cover
 
-            return user
+                return user
 
 
 async def get_user_by_id(user_id: int) -> User:


### PR DESCRIPTION
```log
11-21 23:01:41 [ERROR] sqlalchemy | The garbage collector is trying to clean up non-checked-in connection <AdaptedConnection <Connection(Thread-6, started daemon 16672)>>, which will be dropped, as it cannot be safely terminated.  Please ensure that SQLAlchemy pooled connections are returned to the pool explicitly, either by calling ``close()`` or by using appropriate context managers to manage their lifecycle.
c:\Users\hmy01\.vscode\extensions\ms-python.python-2023.20.0\pythonFiles\lib\python\debugpy\_vendored\pydevd\_pydevd_bundle\pydevd_trace_dispatch_regular.py:436: SAWarning: The garbage collector is trying to clean up non-checked-in connection <AdaptedConnection <Connection(Thread-6, started daemon 16672)>>, which will be dropped, as it cannot be safely terminated.  Please ensure that SQLAlchemy pooled connections are returned to the pool explicitly, either by calling ``close()`` or by using appropriate context managers to manage their lifecycle.
  ret = PyDBFrame(
```