### PR TITLE
ci: 添加 Python 3.12

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,11 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - python-version: "3.11"
-            os: windows-latest
       fail-fast: false
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
并不再排除 Windows 和 Python 3.11 的组合。