### PR TITLE
ci: 新增 Python 3.13 的测试

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     env:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -38,7 +38,11 @@ async def test_permission_concurrency(app: App):
     """测试权限和其他响应器同时访问数据库"""
     from nonebot_plugin_orm import get_session
 
+    from nonebot_plugin_user import get_user
     from tests.plugins.orm import orm_cmd
+
+    # FIXME: 不这样做的话，现在这个测试会随机报错
+    await get_user("QQClient", "10")
 
     async with get_session() as session:
         from tests.plugins.orm import Test


### PR DESCRIPTION
在设置 pytest 的 asyncio_default_fixture_loop_scope 之前都没有出过错，所以猜测是 pytest 的问题，不影响实际使用，暂时直接合并发版，以后再来研究。