### PR TITLE
fix: 避免绑定令牌重复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,24 +46,20 @@
 ## 4. 重要模式与约定
 
 - **命令处理与 Alconna**:
-
   - 用户命令使用 `Alconna`、`Option`、`Args`、`Match`、`Query` 进行结构化定义，不要改成手写字符串解析。
   - `/user` 负责展示和修改用户信息；`/bind` 负责绑定、二阶段群聊绑定和解除绑定。修改命令参数时，需要同步更新 README 和测试期望。
 
 - **用户与会话识别**:
-
   - 跨平台身份来自 `nonebot-plugin-uninfo` 的 `Session`，平台名称优先使用 `session.scope`，平台用户 ID 使用 `session.user.id`。
   - 对外返回用户会话信息时使用 `UserSession`，其中 `session_id` 由 `session.scope` 和 `session.scene_path` 组合。
   - 保留已标记 deprecated 的旧属性时，应继续通过 `typing_extensions.deprecated` 标注，避免直接删除公共 API。
 
 - **绑定流程**:
-
   - `Bind.original_id` 表示初始绑定账号，`Bind.bind_id` 表示当前绑定到的内部账号。解除绑定时只应将 `bind_id` 恢复为 `original_id`，不要删除绑定记录。
   - 群聊绑定是两阶段流程：第一阶段在原始平台验证令牌，第二阶段回到目标平台确认账号；私聊绑定可以直接完成。
   - 绑定令牌应保持短期有效，不要写入日志或持久化存储。测试中如需固定令牌，请 mock 令牌生成函数使用的随机源。
 
 - **数据库访问与迁移**:
-
   - 普通数据库操作使用 `nonebot_plugin_orm.get_session()`。
   - 依赖注入链路中使用 `get_scoped_session()`，新创建的用户需要 merge 回 scoped session。
   - 创建用户和绑定记录时注意并发写入，当前实现通过 `_insert_mutex` 和 `IntegrityError` 兜底处理重复创建。
@@ -71,12 +67,10 @@
   - 修改 `models.py` 中的 ORM 模型后，使用 `nb orm` CLI 生成迁移，并在提交前执行 `uvx --from nb-cli nb orm upgrade` 验证迁移可应用。
 
 - **Pydantic 兼容性**:
-
   - 当前依赖允许 Pydantic v1/v2 共存，模型中保留了 `PYDANTIC_V2` 分支。除非项目明确提升到 Pydantic v2-only，否则不要移除 v1 兼容代码。
   - `pyproject.toml` 中 pyright 定义了 `PYDANTIC_V2 = true`，但运行时仍可能处在兼容依赖范围内。
 
 - **配置**:
-
   - 可变配置应添加到 `config.py` 的 `Config` 模型中，并提供合理默认值。
   - 新配置需要在 README 的配置项部分说明名称、类型、默认值和含义。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复绑定令牌重复时会覆盖已有绑定上下文的问题
+
 ## [0.5.3] - 2025-08-13
 
 ### Added

--- a/nonebot_plugin_user/matchers.py
+++ b/nonebot_plugin_user/matchers.py
@@ -93,7 +93,7 @@ def generate_token() -> str:
         if token not in tokens:
             return token
 
-    raise RuntimeError("生成绑定令牌失败，请稍后重试")
+    raise RuntimeError("生成绑定令牌失败，请稍后重试")  # pragma: no cover
 
 
 bind_cmd = on_alconna(

--- a/nonebot_plugin_user/matchers.py
+++ b/nonebot_plugin_user/matchers.py
@@ -93,7 +93,7 @@ def generate_token() -> str:
         if token not in tokens:
             return token
 
-    raise RuntimeError("生成绑定令牌失败，请稍后重试")  # pragma: no cover
+    raise RuntimeError("生成绑定令牌失败，请稍后重试")
 
 
 bind_cmd = on_alconna(

--- a/nonebot_plugin_user/matchers.py
+++ b/nonebot_plugin_user/matchers.py
@@ -1,5 +1,5 @@
-import random
 import re
+import secrets
 
 from expiringdictx import ExpiringDict
 from nonebot_plugin_alconna import (
@@ -88,7 +88,12 @@ tokens = ExpiringDict[str, tuple[str, str, int, SceneType | None]](capacity=100,
 
 
 def generate_token() -> str:
-    return f"{plugin_config.user_token_prefix}{random.randint(100000, 999999)}"
+    for _ in range(100):
+        token = f"{plugin_config.user_token_prefix}{secrets.randbelow(900000) + 100000}"
+        if token not in tokens:
+            return token
+
+    raise RuntimeError("生成绑定令牌失败，请稍后重试")
 
 
 bind_cmd = on_alconna(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,10 @@ async def app(app: App, mocker: MockerFixture, tmp_path: Path):
 
     # 清理数据库
 
+    from nonebot_plugin_user.matchers import tokens
     from nonebot_plugin_user.models import Bind, User
+
+    tokens.clear()
 
     async with get_session() as session, session.begin():
         await session.execute(delete(Bind))

--- a/tests/test_bind_group.py
+++ b/tests/test_bind_group.py
@@ -11,8 +11,8 @@ async def test_bind_group(app: App, patch_current_time, mocker: MockerFixture):
     """群聊绑定用户"""
     from nonebot_plugin_user.matchers import bind_cmd, user_cmd
 
-    mocked_random = mocker.patch("nonebot_plugin_user.matchers.random.randint")
-    mocked_random.return_value = 123456
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.return_value = 23456
 
     with patch_current_time("2023-09-14 10:46:10", tick=False):
         async with app.test_matcher(user_cmd) as ctx:
@@ -115,8 +115,8 @@ async def test_bind_group_different_user(app: App, patch_current_time, mocker: M
     """群聊绑定用户，不是最开始发送绑定命令的用户"""
     from nonebot_plugin_user.matchers import bind_cmd, user_cmd
 
-    mocked_random = mocker.patch("nonebot_plugin_user.matchers.random.randint")
-    mocked_random.return_value = 123456
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.return_value = 23456
 
     with patch_current_time("2023-09-14 10:46:10", tick=False):
         async with app.test_matcher(user_cmd) as ctx:

--- a/tests/test_bind_private.py
+++ b/tests/test_bind_private.py
@@ -7,12 +7,26 @@ from pytest_mock import MockerFixture
 from tests.fake import fake_private_message_event_v11
 
 
+async def test_generate_token_skips_existing_token(app: App, mocker: MockerFixture):
+    """生成令牌时跳过已有令牌"""
+    from nonebot_plugin_user.matchers import generate_token, tokens
+
+    tokens["nonebot/123456"] = ("QQClient", "1", 1, None)
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.side_effect = [23456, 23457]
+
+    try:
+        assert generate_token() == "nonebot/123457"
+    finally:
+        tokens.pop("nonebot/123456")
+
+
 async def test_bind_private(app: App, patch_current_time, mocker: MockerFixture):
     """私聊绑定用户"""
     from nonebot_plugin_user.matchers import bind_cmd, user_cmd
 
-    mocked_random = mocker.patch("nonebot_plugin_user.matchers.random.randint")
-    mocked_random.return_value = 123456
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.return_value = 23456
 
     with patch_current_time("2023-09-14 10:46:10", tick=False):
         async with app.test_matcher(user_cmd) as ctx:
@@ -94,8 +108,8 @@ async def test_bind_private_invalid_token(app: App, patch_current_time, mocker: 
     """私聊绑定用户，无效的令牌"""
     from nonebot_plugin_user.matchers import bind_cmd, user_cmd
 
-    mocked_random = mocker.patch("nonebot_plugin_user.matchers.random.randint")
-    mocked_random.return_value = 123456
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.return_value = 23456
 
     with patch_current_time("2023-09-14 10:46:10", tick=False):
         async with app.test_matcher(user_cmd) as ctx:
@@ -180,8 +194,8 @@ async def test_bind_private_prefix(app: App, patch_current_time, mocker: MockerF
 
     mocker.patch.object(plugin_config, "user_token_prefix", "test/")
 
-    mocked_random = mocker.patch("nonebot_plugin_user.matchers.random.randint")
-    mocked_random.return_value = 123456
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.return_value = 23456
 
     with patch_current_time("2023-09-14 18:46:10+08:00", tick=False):
         async with app.test_matcher(user_cmd) as ctx:

--- a/tests/test_bind_private.py
+++ b/tests/test_bind_private.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E501
+import pytest
 from nonebot import get_adapter
 from nonebot.adapters.onebot.v11 import Adapter, Bot, Message
 from nonebug import App
@@ -19,6 +20,23 @@ async def test_generate_token_skips_existing_token(app: App, mocker: MockerFixtu
         assert generate_token() == "nonebot/123457"
     finally:
         tokens.pop("nonebot/123456")
+
+
+async def test_generate_token_raises_when_all_retries_conflict(app: App, mocker: MockerFixture):
+    """生成令牌持续重复时抛出错误"""
+    from nonebot_plugin_user.matchers import generate_token, tokens
+
+    tokens["nonebot/123456"] = ("QQClient", "1", 1, None)
+    mocked_randbelow = mocker.patch("nonebot_plugin_user.matchers.secrets.randbelow")
+    mocked_randbelow.return_value = 23456
+
+    try:
+        with pytest.raises(RuntimeError, match="生成绑定令牌失败，请稍后重试"):
+            generate_token()
+    finally:
+        tokens.pop("nonebot/123456")
+
+    assert mocked_randbelow.call_count == 100
 
 
 async def test_bind_private(app: App, patch_current_time, mocker: MockerFixture):


### PR DESCRIPTION
## 变更内容

- 将绑定令牌生成从 `random.randint` 切换为 `secrets.randbelow`。
- 生成绑定令牌时跳过仍在有效期内的已有 token，避免碰撞时覆盖旧绑定上下文。
- 为重复 token 场景补充测试，并在测试夹具中清理全局 token 缓存，避免用例之间互相影响。
- 在 `CHANGELOG.md` 的 `Unreleased` 中记录本次修复。

## 影响范围

- 用户侧 `/bind` 流程和 6 位数字令牌格式不变。
- 令牌碰撞时会重新生成，避免旧 token 被新绑定流程覆盖。
- 极端情况下连续生成重复 token 会抛出明确错误，避免无限循环。

## 验证

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest tests/test_bind_private.py tests/test_bind_group.py`

备注：`AGENTS.md` 编码指南已经在当前分支基线中，包含 `nb orm` CLI 迁移约定。